### PR TITLE
Strokes in signature screen not working

### DIFF
--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -179,6 +179,7 @@ public class RSSignatureCaptureView extends View {
         float eventX = event.getX();
         float eventY = event.getY();
         int moveHistorySize = event.getHistorySize();
+        console.warn({event.getHistorySize()})
 
         switch (event.getAction()) {
             case MotionEvent.ACTION_DOWN:

--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureView.java
@@ -42,6 +42,8 @@ public class RSSignatureCaptureView extends View {
     private float mLastTouchY;
     private float mLastVelocity;
     private float mLastWidth;
+    private float mLastDrawnX;
+    private float mLastDrawnY;
     private float totalStrokeLength;
     private RectF mDirtyRect;
     private Bitmap mBitmapSavedState;
@@ -187,14 +189,16 @@ public class RSSignatureCaptureView extends View {
             case MotionEvent.ACTION_DOWN:
                 getParent().requestDisallowInterceptTouchEvent(true);
                 mPoints.clear();
-                mLastTouchX = eventX;
-                mLastTouchY = eventY;
+                mLastDrawnX = mLastTouchX = eventX;
+                mLastDrawnY = mLastTouchY = eventY;
                 addPoint(getNewPoint(eventX, eventY));
                 if(mOnSignedListener != null) mOnSignedListener.onStartSigning();
 
             case MotionEvent.ACTION_MOVE:
                 resetDirtyRect(eventX, eventY);
                 addTotalLength(eventX, eventY);
+                mLastDrawnX = eventX;
+                mLastDrawnY = eventY;                
                 addPoint(getNewPoint(eventX, eventY));
                 dragged = true;
                 break;
@@ -224,11 +228,11 @@ public class RSSignatureCaptureView extends View {
     }
 
     public void addTotalLength(float newX, float newY) {
-        totalStrokeLength += Math.sqrt((newY - mLastTouchY) * (newY - mLastTouchY) + (newX - mLastTouchX) * (newX - mLastTouchX));
+        totalStrokeLength += Math.sqrt((newY - mLastDrawnY) * (newY - mLastDrawnY) + (newX - mLastDrawnX) * (newX - mLastDrawnX));
     }
 
     public void sendDragEventToReact() {
-        if (callback != null && dragged && totalStrokeLength > 5000.0f) {
+        if (callback != null && dragged && totalStrokeLength > 700.0f) {
             callback.onDragged();
         }
     }


### PR DESCRIPTION
Problem was; the check to know wether a stroke had been made didn't work. It was use to prevent user to be able to send empty or not "long" enough signatures.

Solution (ish) is: I've added a method to compute the total length of strokes made, and only send the dragged event if the length has reach a certain (arbitrary) value.

Please test it on iOS as well as I have no mean of doing that. Also test with different strokes (i.e. fast , slow, straight, curved, etc).

The current limit (I think) is a bit high, but at least we're sure there is a "good enough" signature.

Note that the computed length is somehow not really accurate, because it would seems the down / drag / up events aren't fired correctly?